### PR TITLE
Remove redundant Configure GitHub PHPDocumentation step

### DIFF
--- a/.github/workflows/phpDocumentor.yml
+++ b/.github/workflows/phpDocumentor.yml
@@ -28,11 +28,6 @@ jobs:
         git config --global user.email "actions@github.com"
         git config --global user.name "GitHub Actions"
 
-    - name: Configure GitHub
-      run: |
-       git diff --quiet ./docs
-
-
         
     - name: Check for Documentation Changes & Status
       run: |


### PR DESCRIPTION
---
name: Remove redundant Configure GitHub step
about: Describe the changes made in this pull request
title: ' Removing the redundant step will make the workflow more efficient and easier to understand.'
labels: 'documentation, refactoring'
assignees: ''

---

## Description
This pull request removes the redundant Configure GitHub step from the workflow. This step was previously used to check for changes in the docs directory, but this is now done in the Check for Documentation Changes & Status step. Removing the redundant step will make the workflow more efficient and easier to understand.

## Related Issues
It was checking two thing for same thing

## Screenshots or GIFs (if applicable)
N/A

## Checklist
- [x] I have tested these changes thoroughly.
- [ ] I have updated the documentation if necessary.
- [ ] I have added tests if applicable.
- [x] This pull request has a clear title and description.

## Additional Notes
I agree with your assessment that the Configure GitHub step is redundant. Removing it will make the workflow more efficient and easier to understand.